### PR TITLE
Handling bad user input

### DIFF
--- a/covid19count.py
+++ b/covid19count.py
@@ -33,22 +33,29 @@ def plot_data(regions: List[str], log: bool):
         _get_xls_url(), index_col="DateRep", parse_dates=True
     ).sort_index()
 
+    validregions = False
+
     for region in regions:
-        df_r = df[df["Countries and territories"].str.lower() == region.lower()]
-        df_r = df_r["Cases"].cumsum()
-        # Remove rows before first case
-        df_r = df_r.truncate(before=df_r.ge(1).idxmax())
-        df_r.plot(logy=log, label=region)
+        try:
+          df_r = df[df["Countries and territories"].str.lower() == region.lower()]
+          df_r = df_r["Cases"].cumsum()
+          # Remove rows before first case
+          df_r = df_r.truncate(before=df_r.ge(1).idxmax())
+          df_r.plot(logy=log, label=region)
+          validregions = True
+        except ValueError:
+          print("The region:", region, "was not in the dataset.")
 
-    plt.ylabel("Number of confirmed cases")
-    if log:
-        plt.yscale("log")
+    if ( validregions ):
 
-    end_date = max(df.index).date()
-    plt.title("Confirmed cases per country as of " + str(end_date))
-    plt.legend()
-    plt.show()
+      plt.ylabel("Number of confirmed cases")
+      if log:
+          plt.yscale("log")
 
+      end_date = max(df.index).date()
+      plt.title("Confirmed cases per country as of " + str(end_date))
+      plt.legend()
+      plt.show()
 
 if __name__ == "__main__":
     plot_data()


### PR DESCRIPTION
Today if I enter an invalid region i get:

```
(venv) ➜  covid19count git:(master) ✗ python3 covid19count.py Swede 
Traceback (most recent call last):
  File "covid19count.py", line 54, in <module>
    plot_data()
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "covid19count.py", line 40, in plot_data
    df_r = df_r.truncate(before=df_r.ge(1).idxmax())
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/pandas/core/series.py", line 2110, in idxmax
    i = nanops.nanargmax(com.values_from_object(self), skipna=skipna)
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/pandas/core/nanops.py", line 69, in _f
    return f(*args, **kwargs)
  File "/home/riha/dev/garage/covid19count/venv/lib/python3.7/site-packages/pandas/core/nanops.py", line 875, in nanargmax
    result = values.argmax(axis)
ValueError: attempt to get argmax of an empty sequence

```

with this fix:
```

(venv) ➜  covid19count git:(master) ✗ python3 covid19count.py Swede
The region: Swede was not in the dataset.


```